### PR TITLE
スポンサー募集の2022終了の案内が2023になっていたので修正

### DIFF
--- a/nuxt_src/pages/sponsorship/index.vue
+++ b/nuxt_src/pages/sponsorship/index.vue
@@ -17,7 +17,7 @@
       </div>
 
       <p class="sponsorship_note">
-        2023/2/28 ScalaMatsuri 2023 <strong>スポンサー募集は締め切りました。</strong><br />たくさんのご応募、誠にありがとうございました。
+        2022/2/28 ScalaMatsuri 2022 <strong>スポンサー募集は締め切りました。</strong><br />たくさんのご応募、誠にありがとうございました。
       </p>
     </div>
     <!-- sponsorship ここまで -->


### PR DESCRIPTION
scalamasturi 2022->2023の一括変更でスポンサー募集の箇所も変更されていたので、2022に戻しました。