### PR TITLE
さてらいとスポンサーの体裁を修正

### DIFF
--- a/nuxt_src/pages/sponsorship/index.vue
+++ b/nuxt_src/pages/sponsorship/index.vue
@@ -149,7 +149,7 @@
       <h2 class="section_title">
         <span class="section_title_inner">バーチャルブース</span>
       </h2>
-      <table class="section_table2 section_table2-alignL">
+      <table class="addon-sponsorship-table">
         <tr>
           <th>金額</th>
           <td>¥150,000</td>
@@ -165,7 +165,7 @@
       <h2 class="section_title">
         <span class="section_title_inner">さてらいとスポンサー</span>
       </h2>
-      <table class="section_table2 section_table2-alignL">
+      <table class="addon-sponsorship-table">
         <tr>
           <th>金額</th>
           <td>¥250,000</td>
@@ -241,5 +241,20 @@ export default {
     border-bottom: 2px solid #eba808;
     padding-bottom: 0.1em;
   }
+}
+.addon-sponsorship-table {
+  width: 100%;
+  margin-top: 60px;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+.addon-sponsorship-table th,
+td {
+  border: 1px solid #eee;
+  padding: 1rem;
+  text-align: center;
+}
+.addon-sponsorship-table th {
+  width: 50%;
 }
 </style>


### PR DESCRIPTION
タイトルと金額がそろうように修正しました。

<img width="817" alt="image" src="https://user-images.githubusercontent.com/4135267/220002847-79d24b13-627b-4b0a-b0cb-e6e5c6407b2b.png">

<img width="1560" alt="image" src="https://user-images.githubusercontent.com/4135267/220002885-7d189da6-e6b1-478a-bb30-10309cc77c2d.png">
