### PR TITLE
チケット取得doorkeeperページへのリンク修正 & スポンサーシップバナー表示

### DIFF
--- a/nuxt_src/components/parts/TheHeader.vue
+++ b/nuxt_src/components/parts/TheHeader.vue
@@ -8,7 +8,7 @@ en:
   proposals: Proposals
   outline: Outline
   login: Log in
-  ticket: Doorkeeper
+  ticket: Ticket
   cfp: CFP
   cm: CM
   extra-staff: Extra Staffs(ja)
@@ -22,7 +22,7 @@ ja:
   proposals: セッション候補
   outline: 開催概要
   login: ログイン
-  ticket: Doorkeeper
+  ticket: チケット
   cfp: セッション募集
   cm: CM
   extra-staff: スタッフ募集
@@ -91,11 +91,11 @@ ja:
             <!-- {{ $t('login') }} -->
             <!-- </nuxt-link> -->
             <!-- </div> -->
-            <!-- <li class="function_item function_item-application"> -->
-            <!--   <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener"> -->
-            <!--     {{ $t("ticket") }} -->
-            <!--   </a> -->
-            <!-- </li> -->
+            <li class="function_item function_item-application">
+              <a href="https://scalaconfjp.doorkeeper.jp/events/152333" target="_blank" rel="noopener">
+                {{ $t("ticket") }} -->
+              </a>
+            </li>
             <!-- <li class="function_item function_item-login"> -->
             <!--   <nuxt-link :to="localePath('cfp')"> -->
             <!--     {{ $t("cfp") }} -->
@@ -189,11 +189,11 @@ ja:
               <!--     {{ $t('login') }} -->
               <!--   </nuxt-link> -->
               <!-- </div> -->
-              <!-- <div class="function_item function_item-application"> -->
-              <!--   <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener"> -->
-              <!--     {{ $t("ticket") }} -->
-              <!--   </a> -->
-              <!-- </div> -->
+              <div class="function_item function_item-application">
+                <a href="https://scalaconfjp.doorkeeper.jp/events/152333" target="_blank" rel="noopener">
+                  {{ $t("ticket") }}
+                </a>
+              </div>
               <!-- <div class="function_item function_item-login" @click="toggleMenu()"> -->
               <!--   <nuxt-link :to="localePath('cfp')"> -->
               <!--     {{ $t("cfp") }} -->

--- a/nuxt_src/components/sections/top/Banner.vue
+++ b/nuxt_src/components/sections/top/Banner.vue
@@ -3,30 +3,30 @@
 en:
   sponsorship: "Sponsorship(ja)"
   cfp: "Call for proposals"
-  ticket: "Doorkeepr"
+  ticket: "Ticket"
   tshirt: "Get a (Ninja) T-Shirt"
 ja:
   sponsorship: "スポンサー募集"
   cfp: "セッションに応募する"
-  ticket: "Doorkeepr"
+  ticket: "チケット"
   tshirt: "(忍者)Tシャツ購入"
 </i18n>
 
 <template>
   <div class="banner">
     <div class="banner_list">
-      <!-- <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor"> -->
-      <!--   <span>{{ $t('sponsorship') }} </span> -->
-      <!-- </nuxt-link> -->
+      <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor">
+        <span>{{ $t('sponsorship') }} </span>
+      </nuxt-link>
       <!-- <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff"> -->
       <!--   <span>{{ $t("cfp") }}</span> -->
       <!-- </nuxt-link> -->
       <!-- <a href="https://scalamatsuri-online-shop.myshopify.com/" target="_blank" rel="noopener" class="banner_item banner_item-sponsor"> -->
       <!--   <span>{{ $t('tshirt') }} </span> -->
       <!-- </a> -->
-      <!-- <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener" class="banner_item banner_item-staff"> -->
-      <!--   <span>{{ $t('ticket') }}</span> -->
-      <!-- </a> -->
+      <a href="https://scalaconfjp.doorkeeper.jp/events/152333" target="_blank" rel="noopener" class="banner_item banner_item-staff">
+        <span>{{ $t('ticket') }}</span>
+      </a>
     </div>
   </div>
 </template>

--- a/nuxt_src/components/sections/top/banner.vue
+++ b/nuxt_src/components/sections/top/banner.vue
@@ -3,30 +3,30 @@
 en:
   sponsorship: "Sponsorship(ja)"
   cfp: "Call for proposals"
-  ticket: "Doorkeepr"
+  ticket: "Ticket"
   tshirt: "Get a (Ninja) T-Shirt"
 ja:
   sponsorship: "スポンサー募集"
   cfp: "セッションに応募する"
-  ticket: "Doorkeepr"
+  ticket: "チケット"
   tshirt: "(忍者)Tシャツ購入"
 </i18n>
 
 <template>
   <div class="banner">
     <div class="banner_list">
-      <!-- <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor"> -->
-      <!--   <span>{{ $t('sponsorship') }} </span> -->
-      <!-- </nuxt-link> -->
+      <nuxt-link :to="localePath('sponsorship')" class="banner_item banner_item-sponsor">
+        <span>{{ $t('sponsorship') }} </span>
+      </nuxt-link>
       <!-- <nuxt-link :to="localePath('cfp')" class="banner_item banner_item-staff"> -->
       <!--   <span>{{ $t("cfp") }}</span> -->
       <!-- </nuxt-link> -->
       <!-- <a href="https://scalamatsuri-online-shop.myshopify.com/" target="_blank" rel="noopener" class="banner_item banner_item-sponsor"> -->
       <!--   <span>{{ $t('tshirt') }} </span> -->
       <!-- </a> -->
-      <!-- <a href="https://scalaconfjp.doorkeeper.jp/events/131313" target="_blank" rel="noopener" class="banner_item banner_item-staff"> -->
-      <!--   <span>{{ $t('ticket') }}</span> -->
-      <!-- </a> -->
+      <a href="https://scalaconfjp.doorkeeper.jp/events/152333" target="_blank" rel="noopener" class="banner_item banner_item-staff">
+        <span>{{ $t('ticket') }}</span>
+      </a>
     </div>
   </div>
 </template>


### PR DESCRIPTION
以下の変更を行いました。

- チケット取得doorkeeperページを去年のものからリンク修正 
- コメントアウトで非表示になっていたリンクを活性化
   - 去年のフォーマットに合わせてスポンサーシップのバナーも合わせて表示
   - ![image](https://user-images.githubusercontent.com/1401147/223462373-110a2348-e93a-4309-a697-8a07bd6d0263.png)
   - 文言がチケット購入 => チケットになっている経緯は https://github.com/scalamatsuri/2022.scalamatsuri.org/pull/98#issuecomment-1045966408 参照


## preview

![image](https://user-images.githubusercontent.com/1401147/223462984-e3094601-6b22-4334-b85f-e11823da4888.png)
![image](https://user-images.githubusercontent.com/1401147/223463056-3bf5f54e-a78c-4a05-8a16-37555dea0e33.png)
