### PR TITLE
大澤 昂太さんのセッション英語タイトル修正

### DIFF
--- a/nuxt_src/data/proposals/all.json
+++ b/nuxt_src/data/proposals/all.json
@@ -513,7 +513,7 @@
       "youtube_embed_url_2": ""
     },
     "en": {
-      "title": "After products made with DDD & Scala",
+      "title": "Current state of products made with DDD & Scala.",
       "detail": "",
       "language": "Japanese",
       "length": 20,

--- a/nuxt_src/data/sessions/index.json
+++ b/nuxt_src/data/sessions/index.json
@@ -210,7 +210,7 @@
   },
   {
     "id": "J1681614000",
-    "title": "OSAWA Kota: After products made with DDD & Scala",
+    "title": "OSAWA Kota: Current state of products made with DDD & Scala",
     "startAt": 1681614000,
     "endAt": 1681614900,
     "jst": "2023-04-16 12:00:00",


### PR DESCRIPTION
DAY2 4/16 12:00 大澤 昂太さんのセッションタイトルについて「Current state of products made with DDD & Scala.」へ変更