### PR TITLE
「スピーカーの皆さんへ」のページを復活する

### DIFF
--- a/nuxt_src/pages/speaker/index.vue
+++ b/nuxt_src/pages/speaker/index.vue
@@ -6,7 +6,7 @@ en:
   title_02: Stay in 20min slot
   body_02: |
     The program is tightly arranged this year, with a sequence of short talks.
-    We ask your cooperation to be punctual for both the starting time and the talk time (20min) to respect the attendees and other speakers.
+    We ask your cooperation to be punctual for both the starting time and the talk time (20min or 40min) to respect the attendees and other speakers.
     On the day of the talk, a time keeper will join you in the Zoom Webinar to display the remaining time, which you could glance from time to time.
     <br/>
     <b>In the event the talk runs over, please note that the MC will interrupt your talk.</b>
@@ -34,7 +34,7 @@ ja:
   title_02: 時間厳守
   body_02: |
     本年度のプログラムは短めのトークが次々と続く形で例年よりもタイトになっております。
-    スケジュールの遅れが出ないように、開始時間およびトーク時間 (20分) の時間厳守をお願いしております。
+    スケジュールの遅れが出ないように、開始時間およびトーク時間 (20分又は40分) の時間厳守をお願いしております。
     当日の Zoom Webinar にはタイムキーパーが同席して残り時間を表示するなどするので是非活用してください。
     <br/>
     <b>終了時間オーバーした場合、司会がトークを中断させていただきます。ご了承ください。</b>

--- a/nuxt_src/pages/speaker/index.vue
+++ b/nuxt_src/pages/speaker/index.vue
@@ -22,7 +22,7 @@ en:
     <br>
     During the session, we will use Zoom Webinar's <b>Interpretation</b> feature. Be sure to click the <b>Interpretation</b> button at the bottom right of Zoom Webinar UI and choose <b>English</b> if you'd be giving your talk in English.<br>
     <br>
-    Questions and answers are included in the session time. You can answer as appropriate during the session, or you can answer all at the end of the session. Questions from participants will be written to the <b>track-a</b> channel of Discord. Be sure to read the question aloud before answering these questions. The <b>track-a-chat</b> channel in Discord are for chat. You can see them when you want to see the reaction of the participants.
+    Questions and answers are included in the session time. You can answer as appropriate during the session, or you can answer all at the end of the session. Questions from participants will be written to the <b>main-track</b> channel of Discord. Be sure to read the question aloud before answering these questions. The <b>main-track-chat</b> channel in Discord are for chat. You can see them when you want to see the reaction of the participants.
   title_05: slide link
   body_05: |
     After ScalaMatsuri 2023, we plan to add slide and video links to our website.<br>
@@ -51,8 +51,8 @@ ja:
     同時通訳機能を利用します。スピーカーの皆さんは、Zoom Webinarの右下の「通訳」ボタンをクリックして、必ず自分が話す言語（日本語もしくは英語）を選ぶようにしてください。<br>
     <br>
     質疑応答もセッション時間の中に含まれます。セッション中に適宜回答しても、セッションの最後にまとめて回答してもかまいません。<br>
-    質問はDiscordの <b>track-a</b> チャネルに書き込まれます。必ず質問を読み上げてから、回答するようにしてください。<br>
-    Discordの <b>track-a-chat</b> は雑談チャネルです。参加者の反応が見たいときに利用してください。<br>
+    質問はDiscordの <b>main-track</b> チャネルに書き込まれます。必ず質問を読み上げてから、回答するようにしてください。<br>
+    Discordの <b>main-track-chat</b> は雑談チャネルです。参加者の反応が見たいときに利用してください。<br>
   title_05: スライドリンク共有のお願い
   body_05: |
     ScalaMatsuri 2023終了後、Webサイトにスライドと動画のリンクを追記する予定です。<br>

--- a/nuxt_src/pages/speaker/index.vue
+++ b/nuxt_src/pages/speaker/index.vue
@@ -95,16 +95,13 @@ ja:
 </template>
 
 <script>
-import Page404NotFoundMixin from "~/mixins/page/Page404NotFound.js"
-
 export default {
-  mixins: [Page404NotFoundMixin],
   head() {
     const $t = this.$t.bind(this)
     return {
       title: $t("title_01"),
       meta: [{ name: "og:title", content: `${$t("title_01")} | ScalaMatsuri 2023` }],
     }
-  },
+  }
 }
 </script>


### PR DESCRIPTION
https://github.com/scalajp/2023.staff/issues/268

当日の案内をお送りするためにホームページに注意事項を掲載する



<img width="1504" alt="スクリーンショット 2023-04-10 1 58 31" src="https://user-images.githubusercontent.com/21272619/230786047-aea7fac7-938f-4892-9865-9a9595cc942a.png">
<img width="1467" alt="スクリーンショット 2023-04-10 1 59 07" src="https://user-images.githubusercontent.com/21272619/230786051-26067ffa-e4d8-44cc-8cec-4a05afc630b2.png">

40分のスピーカーさんもいらっしゃるので一部修正
