### PR TITLE
Minor improvements on the bathroom wording

### DIFF
--- a/nuxt_src/pages/code-of-conduct/index.vue
+++ b/nuxt_src/pages/code-of-conduct/index.vue
@@ -38,7 +38,7 @@ en:
     - All sponsors are asked to comply with the Code of conduct when they apply. Their slides and commercial videos are checked beforehand and modified if necessary.
     - All speakers are asked to comply with the Code of conduct when they apply to CFP. Their slides are checked beforehand and modified if necessary.
     - In Open mic conference, the conference organizers will ask speakers to be checked to comply with Code of conduct before their talks. Due the nature of Open mic conference, it will be difficult to guarantee prior check of all contents, so this will require cooperation from all participants.
-    - In our venue, everyone is allowed to use a rest room based on their own gender identity. A non-binary is allowed to use any rest room.
+    - At the conference venues, participants are free to use bathrooms based on their own self-declared gender identity. A non-binary person is allowed to use any bathrooms.
   contacts_during_the_conference_title: Contacts during the conference
   contacts_during_the_conference_text_01: |
     If you are being harassed, notice that someone else is being harassed, please report the following form or contact a nearby conference staff immediately.
@@ -95,7 +95,7 @@ ja:
     - ScalaMatsuriの全てのスポンサーに対し、スポンサー申込時に行動規範準拠の同意を確認しています。また、スライドやCMといった上映コンテンツの事前チェックによる行動規範準拠の確認、そして必要な場合は修正を依頼しています。
     - カンファレンスにおける全ての発表者に対し、CFPへの応募時に行動規範準拠の同意を確認しています。また、スライドの事前チェックによる行動規範準拠の確認、そして必要な場合は修正を依頼しています。
     - 飛び入りカンファレンスでは、全ての発表者に対しスライドの事前チェックを受けるように呼びかけます。飛び入りカンファレンスの性質上、漏れのない事前チェックを保証することは難しいので、皆さんのご協力が特に不可欠です。よろしくお願いします。
-    - 会場のお手洗いは、ご本人のジェンダーアイデンティティに基づいて利用していただいています。非バイナリジェンダーの方は、どのお手洗いでも利用可能としています。
+    - 会場のお手洗いは、ご本人が自己宣言したジェンダーアイデンティティに基づいて利用していただいています。非バイナリジェンダーの方は、どのお手洗いでも利用可能としています。
   contacts_during_the_conference_title: 会期中の報告窓口
   contacts_during_the_conference_text_01: |
     自分や他の人がハラスメントを受けている場合には以下のフォームにてご連絡ください。


### PR DESCRIPTION
It might be a bit redundant but added "self-declared" to clarify that no-one else is going to determine their gender identity.
